### PR TITLE
FindCUDAToolkit requires CMake 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 if( CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR )
     message( FATAL_ERROR "Please select another Build Directory ! (and give it a clever name, like bin_Visual2012_64bits/)" )


### PR DESCRIPTION
find_package(CUDAToolkit) is not provided for CMake versions below 3.17
https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html