### PR TITLE
Allow compilation on Linux systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,7 @@ if(NOT OpenMP_FOUND)
 endif()
 
 if(NOT MSVC)
-	#X11
-	MESSAGE(STATUS "Add X11 and stdc++fs for non windows systems")
-	find_package(X11 REQUIRED)
-	set(LIBS ${LIBS} X11)
+	MESSAGE(STATUS "Add stdc++fs for non windows systems")
 	set(LIBS ${LIBS} stdc++fs)
 endif()
 

--- a/src/DMO/DmoMesh.h
+++ b/src/DMO/DmoMesh.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdexcept>
+#include <sstream>
+
 
 #include "DmoVector.h"
 #include "Vertex.h"
@@ -100,9 +103,12 @@ namespace DMO {
 
                 v.oneRingSize = oneRingCounter - v.oneRingID;
                 if( v.oneRingSize >= MAX_ONE_RING_SIZE ) {
-                    LOG( WARNING ) << "One ring is larger than the maximal allowed one ring size\n"
-                                   << "    v.oneRingSize = " << v.oneRingSize << "\n    MAX_ONE_RING_SIZE = " << MAX_ONE_RING_SIZE
-                                   << "\nAdjust MAX_ONE_RING_SIZE for DMO to run correctly";
+                    std::stringstream error_msg;
+                    error_msg   << "One ring is larger than the maximal allowed one ring size\n"
+                                << "    v.oneRingSize = " << v.oneRingSize << "\n    MAX_ONE_RING_SIZE = " << MAX_ONE_RING_SIZE
+                                << "\nAdjust MAX_ONE_RING_SIZE for DMO to run correctly";
+
+                    throw std::invalid_argument(error_msg.str());
                 }
             }
         }
@@ -169,9 +175,12 @@ namespace DMO {
 
                 v.oneRingSize = oneRingCounter - v.oneRingID;
                 if( v.oneRingSize >= MAX_ONE_RING_SIZE ) {
-                    LOG( WARNING ) << "One ring is larger than the maximal allowed one ring size\n"
-                                   << "    v.oneRingSize = " << v.oneRingSize << "\n    MAX_ONE_RING_SIZE = " << MAX_ONE_RING_SIZE
-                                   << "\nAdjust MAX_ONE_RING_SIZE for DMO to run correctly";
+                    std::stringstream error_msg;
+                    error_msg   << "One ring is larger than the maximal allowed one ring size\n"
+                                << "    v.oneRingSize = " << v.oneRingSize << "\n    MAX_ONE_RING_SIZE = " << MAX_ONE_RING_SIZE
+                                << "\nAdjust MAX_ONE_RING_SIZE for DMO to run correctly";
+
+                    throw std::invalid_argument(error_msg.str());
                 }
             }
         }

--- a/src/DMO/DmoMesh.h
+++ b/src/DMO/DmoMesh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+
 #include "DmoVector.h"
 #include "Vertex.h"
 #include "Set.h"
@@ -28,7 +29,7 @@ namespace DMO {
             createColoring( vhs );
         }
 
-        template<typename MeshT, int set = Set::Inner> static DmoMesh create( MeshT& mesh ) {
+        template<typename MeshT, int set = Set::Inner> static DmoMesh create(const MeshT& mesh ) {
             DmoMesh<useGPU> m;
             m.copyMeshData<MeshT, set>( mesh );
             m.createColoring<MeshT, set>( mesh );
@@ -106,7 +107,7 @@ namespace DMO {
             }
         }
 
-        template<typename MeshT, int set> void copyMeshData( MeshT& mesh ) {
+        template<typename MeshT, int set> void copyMeshData(const MeshT& mesh ) {
             int nVertices        = 0;
             int oneRingVecLength = 0;
 
@@ -240,7 +241,7 @@ namespace DMO {
             }
         }
 
-        template<typename MeshT, int set> void createColoring( MeshT& mesh ) {
+        template<typename MeshT, int set> void createColoring(const MeshT& mesh ) {
             // create coloring scheme
             std::vector<int> colorScheme( mesh.n_vertices(), -2 );
 

--- a/src/DMO/DmoMesh.h
+++ b/src/DMO/DmoMesh.h
@@ -3,6 +3,7 @@
 #include "DmoVector.h"
 #include "Vertex.h"
 #include "Set.h"
+#include "DmoParams.h"
 
 #include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
 


### PR DESCRIPTION
- remove unnecessary use of X11
- ensure DmoParams.h are included
- since no glog dependency is claimed, replace glog calls by throwing std::invalid_argument
- const some of the references