### PR TITLE
Fix warning: template-id not allowed for constructor in C++20

### DIFF
--- a/src/DMO/Solver.h
+++ b/src/DMO/Solver.h
@@ -28,7 +28,7 @@ namespace DMO {
         DmoMesh<true>* dmoMesh2_;
 
       public:
-        Solver<MeshT, MetricT, Metric2T>( MeshT& mesh, MetricT* metric1, DmoMesh<true>* dmoMesh1, Metric2T* metric2 = nullptr,
+        Solver( MeshT& mesh, MetricT* metric1, DmoMesh<true>* dmoMesh1, Metric2T* metric2 = nullptr,
                                           DmoMesh<true>* dmoMesh2 = nullptr );
 
         void solve( int nIterations = 100 );

--- a/src/DMO/SolverCPU.h
+++ b/src/DMO/SolverCPU.h
@@ -26,7 +26,7 @@ namespace DMO {
         DmoMesh<false>* dmoMesh2_;
 
       public:
-        SolverCPU<MeshT, MetricT, Metric2T>( MeshT& mesh, MetricT* metric1, DmoMesh<false>* dmoMesh1, Metric2T* metric2 = nullptr,
+        SolverCPU( MeshT& mesh, MetricT* metric1, DmoMesh<false>* dmoMesh1, Metric2T* metric2 = nullptr,
                                              DmoMesh<false>* dmoMesh2 = nullptr );
 
         void solve( int nIterations = 100 );


### PR DESCRIPTION
Future proof DMO

Example Showcase of the problem: https://godbolt.org/z/o13xs76GY

In our case it actually broke compilation with a weird error: `error: expected ')' before '&' token`